### PR TITLE
Fix value format in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,4 +9,4 @@ insert_final_newline = true
 end_of_line = lf
 
 # editorconfig-tools is unable to ignore longs strings or urls
-max_line_length = null
+max_line_length = off


### PR DESCRIPTION
Ahoj Ondro,
všiml jsem si, že ti selhává analýza pylintu kvůli nesprávné hodnotě  v `.editorconfig`, tak ti poslímám rychlý fix. Mělo by ti to ukázat necelou stovku převázně estetických issues navíc v Python scriptech.

Měj se fajn,
Michal